### PR TITLE
upgrade cache-dit api

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,8 +702,9 @@ cache_dit.enable_cache(
     pipeline,
     # Basic DBCache w/ FnBn configurations
     cache_config=DBCacheConfig(
-        max_warmup_steps=0,  # steps do not cache
+        max_warmup_steps=8,  # steps do not cache
         max_cached_steps=-1, # -1 means no limit
+        max_continuous_cached_steps=2, # limit continuous cacheed steps -> 2
         Fn_compute_blocks=1, # Fn, F1, etc.
         Bn_compute_blocks=0, # Bn, B0, etc.
         residual_diff_threshold=0.12,

--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ image = pipe(prompt, num_inference_steps=4).images[0]
 You can use `cache-dit` to further speedup FLUX model, different configurations of compute blocks (F12B12, etc.) can be customized in cache-dit: DBCache. Please check [cache-dit](https://github.com/vipshop/cache-dit) for more details. For example:
 
 ```python
-# Install: pip install git+https://github.com/vipshop/cache-dit.git
+# Install: pip install -U cache-dit
 import cache_dit
 from diffusers import FluxPipeline
 
@@ -696,7 +696,7 @@ pipeline = FluxPipeline.from_pretrained(
 cache_dit.enable_cache(pipe_or_adapter)
 
 # Or using custom options via cache configs
-from cache_dit import BasicCacheConfig, TaylorSeerCalibratorConfig
+from cache_dit import DBCacheConfig, TaylorSeerCalibratorConfig
 
 cache_dit.enable_cache(
     pipeline,

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ from cache_dit import DBCacheConfig, TaylorSeerCalibratorConfig
 cache_dit.enable_cache(
     pipeline,
     # Basic DBCache w/ FnBn configurations
-    cache_config=BasicCacheConfig(
+    cache_config=DBCacheConfig(
         max_warmup_steps=0,  # steps do not cache
         max_cached_steps=-1, # -1 means no limit
         Fn_compute_blocks=1, # Fn, F1, etc.

--- a/README.md
+++ b/README.md
@@ -682,34 +682,38 @@ image = pipe(prompt, num_inference_steps=4).images[0]
 You can use `cache-dit` to further speedup FLUX model, different configurations of compute blocks (F12B12, etc.) can be customized in cache-dit: DBCache. Please check [cache-dit](https://github.com/vipshop/cache-dit) for more details. For example:
 
 ```python
-# Install: pip install -U cache-dit
+# Install: pip3 install git+https://github.com/vipshop/cache-dit.git
+import cache_dit
 from diffusers import FluxPipeline
-from cache_dit.cache_factory import apply_cache_on_pipe, CacheType
 
 pipeline = FluxPipeline.from_pretrained(
     "black-forest-labs/FLUX.1-dev",
     torch_dtype=torch.bfloat16,
 ).to("cuda")
 
-# cache-dit: DBCache configs
-cache_options = {
-    "cache_type": CacheType.DBCache,
-    "warmup_steps": 0,
-    "max_cached_steps": -1,  # -1 means no limit
-    "Fn_compute_blocks": 1,  # Fn, F1, F12, etc.
-    "Bn_compute_blocks": 0,  # Bn, B0, B12, etc.
-    "residual_diff_threshold": 0.12,
-    # TaylorSeer options
-    "enable_taylorseer": True,
-    "enable_encoder_taylorseer": True,
-    # Taylorseer cache type cache be hidden_states or residual
-    "taylorseer_cache_type": "residual",
-    "taylorseer_kwargs": {
-         "n_derivatives": 2,
-    },
-}
+# Default options, F8B0, 8 warmup steps, and unlimited cached 
+# steps for good balance between performance and precision
+cache_dit.enable_cache(pipe_or_adapter)
 
-apply_cache_on_pipe(pipeline, **cache_options)
+# Or using custom options via cache configs
+from cache_dit import BasicCacheConfig, TaylorSeerCalibratorConfig
+
+cache_dit.enable_cache(
+    pipeline,
+    # Basic DBCache w/ FnBn configurations
+    cache_config=BasicCacheConfig(
+        max_warmup_steps=0,  # steps do not cache
+        max_cached_steps=-1, # -1 means no limit
+        Fn_compute_blocks=1, # Fn, F1, etc.
+        Bn_compute_blocks=0, # Bn, B0, etc.
+        residual_diff_threshold=0.12,
+    ),
+    # Then, you can use the TaylorSeer Calibrator to approximate 
+    # the values in cached steps, taylorseer_order default is 1.
+    calibrator_config=TaylorSeerCalibratorConfig(
+        taylorseer_order=1,
+    ),
+)
 ```
 
 By the way, `cache-dit` is designed to work compatibly with torch.compile. You can easily use `cache-dit` with torch.compile to further achieve a better performance. For example:

--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ image = pipe(prompt, num_inference_steps=4).images[0]
 You can use `cache-dit` to further speedup FLUX model, different configurations of compute blocks (F12B12, etc.) can be customized in cache-dit: DBCache. Please check [cache-dit](https://github.com/vipshop/cache-dit) for more details. For example:
 
 ```python
-# Install: pip3 install git+https://github.com/vipshop/cache-dit.git
+# Install: pip install git+https://github.com/vipshop/cache-dit.git
 import cache_dit
 from diffusers import FluxPipeline
 

--- a/cache_config.yaml
+++ b/cache_config.yaml
@@ -1,11 +1,10 @@
-cache_type: DBCache
-warmup_steps: 0
+max_warmup_steps: 0
 max_cached_steps: -1
+max_continuous_cached_steps: 2
 Fn_compute_blocks: 1
 Bn_compute_blocks: 0
 residual_diff_threshold: 0.12
 enable_taylorseer: true
 enable_encoder_taylorseer: true
 taylorseer_cache_type: residual
-taylorseer_kwargs:
-  n_derivatives: 2
+taylorseer_order: 2

--- a/cache_config.yaml
+++ b/cache_config.yaml
@@ -3,7 +3,7 @@ max_cached_steps: -1
 max_continuous_cached_steps: 2
 Fn_compute_blocks: 1
 Bn_compute_blocks: 0
-residual_diff_threshold: 0.12
+residual_diff_threshold: 0.30
 enable_taylorseer: true
 enable_encoder_taylorseer: true
 taylorseer_cache_type: residual

--- a/cache_config.yaml
+++ b/cache_config.yaml
@@ -1,4 +1,4 @@
-max_warmup_steps: 0
+max_warmup_steps: 8
 max_cached_steps: -1
 max_continuous_cached_steps: 2
 Fn_compute_blocks: 1
@@ -7,4 +7,4 @@ residual_diff_threshold: 0.12
 enable_taylorseer: true
 enable_encoder_taylorseer: true
 taylorseer_cache_type: residual
-taylorseer_order: 2
+taylorseer_order: 1

--- a/cache_config.yaml
+++ b/cache_config.yaml
@@ -3,7 +3,7 @@ max_cached_steps: -1
 max_continuous_cached_steps: 2
 Fn_compute_blocks: 1
 Bn_compute_blocks: 0
-residual_diff_threshold: 0.30
+residual_diff_threshold: 0.12
 enable_taylorseer: true
 enable_encoder_taylorseer: true
 taylorseer_cache_type: residual

--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -55,8 +55,11 @@ def main(args):
     image.save(args.output_file)
 
     if args.cache_dit_config is not None:
-        import cache_dit 
-        cache_dit.summary(pipeline)
+        try:
+            import cache_dit 
+            cache_dit.summary(pipeline)
+        except ImportError:
+            print("cache-dit not installed, please install it to see cache-dit summary")
 
     # optionally generate PyTorch Profiler trace
     # this is done after benchmarking because tracing introduces overhead

--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -54,6 +54,10 @@ def main(args):
     print('time mean/var:', timings, timings.mean().item(), timings.var().item())
     image.save(args.output_file)
 
+    if args.cache_dit_config is not None:
+        import cache_dit 
+        cache_dit.summary(pipeline)
+
     # optionally generate PyTorch Profiler trace
     # this is done after benchmarking because tracing introduces overhead
     if args.trace_file is not None:

--- a/utils/pipeline_utils.py
+++ b/utils/pipeline_utils.py
@@ -407,12 +407,11 @@ def optimize(pipeline, args):
             )
         try:
             # docs: https://github.com/vipshop/cache-dit
-            from cache_dit.cache_factory import apply_cache_on_pipe
-            from cache_dit.cache_factory import load_cache_options_from_yaml
-            cache_options = load_cache_options_from_yaml(
-                args.cache_dit_config
+            import cache_dit
+            
+            cache_dit.enable_cache(
+                pipeline, **cache_dit.load_options(args.cache_dit_config),
             )
-            apply_cache_on_pipe(pipeline, **cache_options)
         except ImportError as e:
             print(
                 "You have passed the '--cache_dit_config' flag, but we cannot "


### PR DESCRIPTION
upgrade cache-dit api to 1.0.x

```bash
python3 run_benchmark.py \
    --ckpt ${CKPT} \
    --trace-file optimized_cache_dit.json.gz \
    --compile_export_mode compile \
    --disable_fa3 \
    --num_inference_steps 28 \
    --cache_dit_config cache_config.yaml \
    --output-file optimized_cache_dit.png --disable_quant

Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 40.76it/s]
Loading pipeline components...:  71%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏                                                | 5/7 [00:00<00:00, 14.82it/s]You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 78.88it/s]
Loading pipeline components...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 10.54it/s]
INFO 10-11 06:19:58 [cache_adapter.py:46] FluxPipeline is officially supported by cache-dit. Use it's pre-defined BlockAdapter directly!
INFO 10-11 06:19:58 [block_adapters.py:201] Auto fill blocks_name: ['transformer_blocks', 'single_transformer_blocks'].
INFO 10-11 06:19:58 [block_adapters.py:482] Match Block Forward Pattern: FluxTransformerBlock, ForwardPattern.Pattern_1
INFO 10-11 06:19:58 [block_adapters.py:482] IN:('hidden_states', 'encoder_hidden_states'), OUT:('encoder_hidden_states', 'hidden_states'))
INFO 10-11 06:19:58 [block_adapters.py:482] Match Block Forward Pattern: FluxSingleTransformerBlock, ForwardPattern.Pattern_1
INFO 10-11 06:19:58 [block_adapters.py:482] IN:('hidden_states', 'encoder_hidden_states'), OUT:('encoder_hidden_states', 'hidden_states'))
INFO 10-11 06:19:58 [cache_adapter.py:141] Use default 'enable_separate_cfg' from block adapter register: False, Pipeline: FluxPipeline.
INFO 10-11 06:19:58 [cache_adapter.py:275] Collected Cache Config: DBCACHE_F1B0_W0M0MC2_R0.3, Calibrator Config: TaylorSeer_O(2)
INFO 10-11 06:19:58 [cache_adapter.py:275] Collected Cache Config: DBCACHE_F1B0_W0M0MC2_R0.3, Calibrator Config: TaylorSeer_O(2)
INFO 10-11 06:19:58 [pattern_base.py:51] Match Cached Blocks: CachedBlocks_Pattern_0_1_2, for transformer_blocks, cache_context: transformer_blocks_140567643384928, cache_manager: FluxPipeline_140567649235936.
INFO 10-11 06:19:58 [pattern_base.py:51] Match Cached Blocks: CachedBlocks_Pattern_0_1_2, for single_transformer_blocks, cache_context: single_transformer_blocks_140567528265904, cache_manager: FluxPipeline_140567649235936.
time mean/var: tensor([13.3521, 13.3886, 13.4104, 13.4335, 13.4646, 13.4767, 13.4747, 13.4828,
        13.4852, 13.4868]) 13.445541381835938 0.0022438988089561462

🤗Cache Options: FluxSingleTransformerBlock

{'cache_config': BasicCacheConfig(Fn_compute_blocks=1, Bn_compute_blocks=0, residual_diff_threshold=0.3, max_warmup_steps=0, max_cached_steps=-1, max_continuous_cached_steps=2, enable_separate_cfg=False, cfg_compute_first=False, cfg_diff_compute_separate=True), 'calibrator_config': TaylorSeerCalibratorConfig(enable_calibrator=True, enable_encoder_calibrator=True, calibrator_type='taylorseer', calibrator_cache_type='residual', calibrator_kwargs={}, taylorseer_order=2), 'name': 'single_transformer_blocks_140567528265904'}

⚡️Cache Steps and Residual Diffs Statistics: FluxSingleTransformerBlock

| Cache Steps | Diffs P00 | Diffs P25 | Diffs P50 | Diffs P75 | Diffs P95 | Diffs Min | Diffs Max |
|-------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
| 7           | 0.117     | 0.304     | 0.523     | 0.6       | 0.769     | 0.117     | 0.793     |


🤗Cache Options: FluxTransformerBlock

{'cache_config': BasicCacheConfig(Fn_compute_blocks=1, Bn_compute_blocks=0, residual_diff_threshold=0.3, max_warmup_steps=0, max_cached_steps=-1, max_continuous_cached_steps=2, enable_separate_cfg=False, cfg_compute_first=False, cfg_diff_compute_separate=True), 'calibrator_config': TaylorSeerCalibratorConfig(enable_calibrator=True, enable_encoder_calibrator=True, calibrator_type='taylorseer', calibrator_cache_type='residual', calibrator_kwargs={}, taylorseer_order=2), 'name': 'transformer_blocks_140567643384928'}

⚡️Cache Steps and Residual Diffs Statistics: FluxTransformerBlock

| Cache Steps | Diffs P00 | Diffs P25 | Diffs P50 | Diffs P75 | Diffs P95 | Diffs Min | Diffs Max |
|-------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
| 17          | 0.034     | 0.064     | 0.111     | 0.163     | 0.312     | 0.034     | 0.32      |
```

- baseline: NVIDIA L20, 25s 

<img width="1024" height="1024" alt="bf16" src="https://github.com/user-attachments/assets/0a4ea7bc-03af-47bb-8728-d6f9fba1a8bb" />


- w/ cache-dit: NVIDIA L20, 13s 

<img width="1024" height="1024" alt="optimized_cache_dit" src="https://github.com/user-attachments/assets/77088a27-c79f-42f8-a576-0507df68a0d4" />

